### PR TITLE
Add Blender scripting toolkit with simulated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pre-commit
+        run: pre-commit run --files $(git ls-files '*.py')
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.venv/
+build/
+dist/
+*.egg-info/
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Project Guidelines
+
+- Use Python 3.11 or newer.
+- Format code with Black and ensure Flake8 passes.
+- Run `pre-commit run --files <files>` before committing.
+- Execute the full test suite via `pytest`.
+- Wrap potentially destructive Blender operations with a `dry_run` flag.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Blender Scripting Toolkit
+
+Utilities for developing Blender automation outside the Blender UI. The toolkit relies on [fake-bpy-module](https://github.com/nutti/fake-bpy-module) to simulate Blender's API so scripts can be linted and tested without launching Blender.
+
+## Setup
+
+```sh
+set -euo pipefail
+python -m pip install -r requirements.txt
+```
+
+## Usage
+
+Example: export selected objects as FBX with a safety dry run.
+
+```python
+from scripts import export
+export.export_fbx(["Cube"], "out.fbx", dry_run=True)
+```
+
+Run tests and linters before committing:
+
+```sh
+set -euo pipefail
+pre-commit run --files $(git ls-files '*.py')
+pytest
+```
+
+## References
+
+- [Blender Manual – Export Scene Operators](https://docs.blender.org/api/current/bpy.ops.export_scene.html)
+- [fake-bpy-module README](https://github.com/nutti/fake-bpy-module)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pre-commit==4.3.0
+pytest==8.4.2
+black==25.1.0
+flake8==7.3.0
+fake-bpy-module==20250914

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Blender scripting toolkit modules."""
+
+from . import export, optimize, shader, animation
+
+__all__ = ["export", "optimize", "shader", "animation"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,5 +1,5 @@
 """Blender scripting toolkit modules."""
 
-from . import export, optimize, shader, animation
+from . import animation, export, optimize, shader
 
 __all__ = ["export", "optimize", "shader", "animation"]

--- a/scripts/animation.py
+++ b/scripts/animation.py
@@ -1,0 +1,27 @@
+"""Animation helpers."""
+
+from __future__ import annotations
+from typing import Iterable, Sequence, List, Tuple
+
+try:
+    import bpy
+except ModuleNotFoundError:  # pragma: no cover
+    bpy = None  # type: ignore
+
+
+def apply_location_keyframes(
+    obj,
+    frames: Iterable[int],
+    locations: Iterable[Sequence[float]],
+    dry_run: bool = False,
+) -> List[Tuple[int, Sequence[float]]]:
+    """Insert location keyframes for *obj*.
+
+    Returns a list of ``(frame, location)`` tuples."""
+    data = list(zip(frames, locations))
+    if dry_run or bpy is None:
+        return data
+    for frame, loc in data:
+        obj.location = loc
+        obj.keyframe_insert(data_path="location", frame=frame)
+    return data

--- a/scripts/animation.py
+++ b/scripts/animation.py
@@ -1,7 +1,8 @@
 """Animation helpers."""
 
 from __future__ import annotations
-from typing import Iterable, Sequence, List, Tuple
+
+from typing import Iterable, List, Sequence, Tuple
 
 try:
     import bpy

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,0 +1,34 @@
+"""Export utilities using Blender's API."""
+
+from __future__ import annotations
+from typing import Iterable
+
+try:
+    import bpy
+except ModuleNotFoundError:  # pragma: no cover
+    bpy = None  # type: ignore
+
+
+def _select_objects(names: Iterable[str]) -> None:
+    for obj in bpy.data.objects:
+        obj.select_set(obj.name in names)
+
+
+def export_fbx(objects: Iterable[str], filepath: str, dry_run: bool = False) -> str:
+    """Export objects to an FBX file."""
+    if dry_run or bpy is None:
+        print(f"[DRY RUN] Would export {list(objects)} to {filepath}")
+        return filepath
+    _select_objects(objects)
+    bpy.ops.export_scene.fbx(filepath=filepath, use_selection=True)
+    return filepath
+
+
+def export_gltf(objects: Iterable[str], filepath: str, dry_run: bool = False) -> str:
+    """Export objects to a GLTF file."""
+    if dry_run or bpy is None:
+        print(f"[DRY RUN] Would export {list(objects)} to {filepath}")
+        return filepath
+    _select_objects(objects)
+    bpy.ops.export_scene.gltf(filepath=filepath, export_selected=True)
+    return filepath

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,6 +1,7 @@
 """Export utilities using Blender's API."""
 
 from __future__ import annotations
+
 from typing import Iterable
 
 try:

--- a/scripts/optimize.py
+++ b/scripts/optimize.py
@@ -1,0 +1,22 @@
+"""Optimization helpers."""
+
+from __future__ import annotations
+
+try:
+    import bpy
+except ModuleNotFoundError:  # pragma: no cover
+    bpy = None  # type: ignore
+
+
+def decimate_object(
+    obj, ratio: float, apply: bool = False, dry_run: bool = False
+) -> float:
+    """Apply a decimate modifier to *obj* with the given *ratio*."""
+    if dry_run or bpy is None:
+        print(f"[DRY RUN] Would decimate {getattr(obj, 'name', 'obj')} to {ratio}")
+        return ratio
+    modifier = obj.modifiers.new(name="Decimate", type="DECIMATE")
+    modifier.ratio = ratio
+    if apply:
+        bpy.ops.object.modifier_apply(modifier=modifier.name)
+    return modifier.ratio

--- a/scripts/shader.py
+++ b/scripts/shader.py
@@ -1,0 +1,24 @@
+"""Shader node tree builders."""
+
+from __future__ import annotations
+from typing import Sequence
+
+try:
+    import bpy
+except ModuleNotFoundError:  # pragma: no cover
+    bpy = None  # type: ignore
+
+
+def create_emission_material(name: str, color: Sequence[float]):
+    """Create an emission material with the given RGBA color."""
+    if bpy is None:
+        raise RuntimeError("bpy unavailable")
+    mat = bpy.data.materials.new(name)
+    mat.use_nodes = True
+    nodes = mat.node_tree.nodes
+    nodes.clear()
+    emission = nodes.new("ShaderNodeEmission")
+    emission.inputs["Color"].default_value = (*color, 1.0)
+    output = nodes.new("ShaderNodeOutputMaterial")
+    mat.node_tree.links.new(emission.outputs["Emission"], output.inputs["Surface"])
+    return mat

--- a/scripts/shader.py
+++ b/scripts/shader.py
@@ -1,6 +1,7 @@
 """Shader node tree builders."""
 
 from __future__ import annotations
+
 from typing import Sequence
 
 try:

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,20 @@
+from scripts import animation
+
+
+class Obj:
+    def __init__(self):
+        self.location = (0.0, 0.0, 0.0)
+        self.inserted = []
+
+    def keyframe_insert(self, data_path, frame):
+        self.inserted.append((data_path, frame))
+
+
+def test_apply_location_keyframes():
+    obj = Obj()
+    frames = [1, 5]
+    locs = [(0, 0, 0), (1, 2, 3)]
+    result = animation.apply_location_keyframes(obj, frames, locs)
+    assert result == list(zip(frames, locs))
+    assert obj.inserted == [("location", 1), ("location", 5)]
+    assert obj.location == (1, 2, 3)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,30 @@
+import types
+from scripts import export
+
+
+def test_export_fbx(monkeypatch):
+    calls = {}
+    fake_bpy = types.SimpleNamespace()
+    obj = types.SimpleNamespace(name="Cube", select_set=lambda value: None)
+    fake_bpy.data = types.SimpleNamespace(objects=[obj])
+    fake_bpy.ops = types.SimpleNamespace(
+        export_scene=types.SimpleNamespace(fbx=lambda **kwargs: calls.update(kwargs))
+    )
+    monkeypatch.setattr(export, "bpy", fake_bpy)
+    path = export.export_fbx(["Cube"], "/tmp/test.fbx")
+    assert path == "/tmp/test.fbx"
+    assert calls["filepath"] == "/tmp/test.fbx"
+
+
+def test_export_gltf(monkeypatch):
+    calls = {}
+    fake_bpy = types.SimpleNamespace()
+    obj = types.SimpleNamespace(name="Cube", select_set=lambda value: None)
+    fake_bpy.data = types.SimpleNamespace(objects=[obj])
+    fake_bpy.ops = types.SimpleNamespace(
+        export_scene=types.SimpleNamespace(gltf=lambda **kwargs: calls.update(kwargs))
+    )
+    monkeypatch.setattr(export, "bpy", fake_bpy)
+    path = export.export_gltf(["Cube"], "/tmp/test.gltf")
+    assert path == "/tmp/test.gltf"
+    assert calls["filepath"] == "/tmp/test.gltf"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,5 @@
 import types
+
 from scripts import export
 
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,4 +1,5 @@
 import types
+
 from scripts import optimize
 
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,34 @@
+import types
+from scripts import optimize
+
+
+class MockModifiers:
+    def __init__(self):
+        self.created = []
+
+    def new(self, name, type):
+        mod = types.SimpleNamespace(name=name, type=type, ratio=1.0)
+        self.created.append(mod)
+        return mod
+
+
+class MockObject:
+    def __init__(self):
+        self.modifiers = MockModifiers()
+
+
+def test_decimate(monkeypatch):
+    applied = {}
+    fake_bpy = types.SimpleNamespace(
+        ops=types.SimpleNamespace(
+            object=types.SimpleNamespace(
+                modifier_apply=lambda modifier: applied.setdefault("name", modifier)
+            )
+        )
+    )
+    monkeypatch.setattr(optimize, "bpy", fake_bpy)
+    obj = MockObject()
+    ratio = optimize.decimate_object(obj, 0.25, apply=True)
+    assert obj.modifiers.created[0].ratio == 0.25
+    assert applied["name"] == "Decimate"
+    assert ratio == 0.25

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,4 +1,5 @@
 import types
+
 from scripts import shader
 
 

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,0 +1,47 @@
+import types
+from scripts import shader
+
+
+class FakeNodes(dict):
+    def clear(self):
+        super().clear()
+
+    def new(self, node_type):
+        if node_type == "ShaderNodeEmission":
+            node = types.SimpleNamespace(
+                name="Emission",
+                inputs={"Color": types.SimpleNamespace(default_value=[0, 0, 0, 0])},
+                outputs={"Emission": object()},
+            )
+        else:
+            node = types.SimpleNamespace(
+                name="Material Output", inputs={"Surface": object()}, outputs={}
+            )
+        self[node.name] = node
+        return node
+
+
+class FakeNodeTree:
+    def __init__(self):
+        self.nodes = FakeNodes()
+        self.links = types.SimpleNamespace(new=lambda *args, **kwargs: None)
+
+
+class FakeMaterials(dict):
+    def new(self, name):
+        mat = types.SimpleNamespace(
+            name=name, use_nodes=False, node_tree=FakeNodeTree()
+        )
+        self[name] = mat
+        return mat
+
+
+def test_create_emission_material(monkeypatch):
+    fake_bpy = types.SimpleNamespace(
+        data=types.SimpleNamespace(materials=FakeMaterials())
+    )
+    monkeypatch.setattr(shader, "bpy", fake_bpy)
+    mat = shader.create_emission_material("MyMat", (0.2, 0.3, 0.4))
+    emission = mat.node_tree.nodes["Emission"]
+    color = emission.inputs["Color"].default_value
+    assert tuple(color[:3]) == (0.2, 0.3, 0.4)


### PR DESCRIPTION
## Summary
- document project conventions and setup
- add export, optimization, shader, and animation modules
- provide test harness and CI workflow

## Testing
- `pre-commit run --files $(find scripts tests -name '*.py')` (partial run shown)
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1edcd64832bb65c98938e4d3e85